### PR TITLE
change Text to Widget to allow more types

### DIFF
--- a/lib/flashy_tab_bar2.dart
+++ b/lib/flashy_tab_bar2.dart
@@ -102,7 +102,7 @@ class FlashyTabBarItem {
   Color activeColor;
   final Widget icon;
   Color inactiveColor;
-  final Text title;
+  final Widget title;
 }
 
 class _FlashTabBarItem extends StatelessWidget {


### PR DESCRIPTION
As the title suggest, chosing Widget will allow more variaty, in my case when I click on tab bar item, it'll animate to an Icon instead of Text